### PR TITLE
bld: Remove glfw dependency when library. Only used for the test

### DIFF
--- a/vulkan.nimble
+++ b/vulkan.nimble
@@ -10,11 +10,11 @@ skipDirs    = @["tests"]
 # Dependencies
 
 requires "nim >= 1.0.0"
-requires "https://github.com/DanielBelmes/glfw#head"
 
 task gen, "Generate bindings from source":
   exec("nim c -d:ssl -r tools/generator.nim")
 
+taskRequires "test", "https://github.com/DanielBelmes/glfw#head"
 task test, "Create basic triangle with Vulkan and GLFW":
   requires "nimgl@#1.0" # Please https://github.com/nim-lang/nimble/issues/482
   exec("nim c -r -d:release tests/test.nim")


### PR DESCRIPTION
Uses the new "taskRequires" feature of nimble, to avoid everyone depending on a specific windowing library.
Still supports the test like before, no changes.
The change only applies when the library is imported.